### PR TITLE
Adds python syntax highlighting in yellow

### DIFF
--- a/vim/lavalamp.vim
+++ b/vim/lavalamp.vim
@@ -608,6 +608,7 @@ endif
 :exe 'hi jstDelimiter'            .fg_green_xlight
 
 " Python
+" using python syntax: https://github.com/hdima/python-syntax
 if &background == "dark"
   :exe 'hi pythonStatement'       .fg_white . gui_bold
   :exe 'hi pythonDecorator'       .fg_yellow_xlight . gui_bold


### PR DESCRIPTION
This PR fixes #8

Here are some screenshots of it:
![screen shot 1730-10-30 at 11 26 37](https://cloud.githubusercontent.com/assets/2810764/3497404/7b1a249c-05eb-11e4-81b4-aaf1d7bf9007.png)
This shot shows a good amount of the breadth shown in the python syntax.

![screen shot 1730-10-30 at 11 26 06](https://cloud.githubusercontent.com/assets/2810764/3497409/96040e9e-05eb-11e4-8102-e6b8d4e5e3c0.png)
This shot shows a large amount of python's templating (here using Jinja2, but it also works with django templating)

Let me know what you think!
