### PR TITLE
fixes seemingly out of place red and green in css files

### DIFF
--- a/vim/lavalamp.vim
+++ b/vim/lavalamp.vim
@@ -114,11 +114,13 @@ let fg_purple_xdark  = ' guifg='.purple_xdark
 :let orange_dark   = '#d18747'
 :let orange_xdark  = '#c2691d'
 
-:let yellow_xlight = '#f8f18c'
-:let yellow_light  = '#f8ee65'
-:let yellow_med    = '#f1e432'
-:let yellow_dark   = '#b5ad49'
-:let yellow_xdark  = '#9d9310'
+:let yellow_xlight      = '#fbb917'
+:let yellow_light       = '#fdd017'
+:let yellow_light_soft  = '#ffdb58'
+:let yellow_med         = '#f1e432'
+:let yellow_dark        = '#e9ab17'
+:let yellow_xdark       = '#9d9310'
+:let yellow_muted       = '#ede275'
 
 :let green_xlight = '#c3e881'
 :let green_light  = '#b6e85c'
@@ -152,17 +154,21 @@ let fg_purple_xdark  = ' guifg='.purple_xdark
 :let fg_orange_dark   = ' guifg='.orange_dark
 :let fg_orange_xdark  = ' guifg='.orange_xdark
 
-:let fg_yellow_xlight = ' guifg='.yellow_xlight
-:let fg_yellow_light  = ' guifg='.yellow_light
-:let fg_yellow_med    = ' guifg='.yellow_med
-:let fg_yellow_dark   = ' guifg='.yellow_dark
-:let fg_yellow_xdark  = ' guifg='.yellow_xdark
+:let fg_yellow_xlight     = ' guifg='.yellow_xlight
+:let fg_yellow_light      = ' guifg='.yellow_light
+:let fg_yellow_med        = ' guifg='.yellow_med
+:let fg_yellow_dark       = ' guifg='.yellow_dark
+:let fg_yellow_xdark      = ' guifg='.yellow_xdark
+:let fg_yellow_muted      = ' guifg='.yellow_muted
+:let fg_yellow_light_soft = ' guifg='.yellow_light_soft
 
-:let bg_yellow_xlight = ' guibg='.yellow_xlight
-:let bg_yellow_light  = ' guibg='.yellow_light
-:let bg_yellow_med    = ' guibg='.yellow_med
-:let bg_yellow_dark   = ' guibg='.yellow_dark
-:let bg_yellow_xdark  = ' guibg='.yellow_xdark
+:let bg_yellow_xlight     = ' guibg='.yellow_xlight
+:let bg_yellow_light      = ' guibg='.yellow_light
+:let bg_yellow_med        = ' guibg='.yellow_med
+:let bg_yellow_dark       = ' guibg='.yellow_dark
+:let bg_yellow_xdark      = ' guibg='.yellow_xdark
+:let bg_yellow_muted      = ' guibg='.yellow_muted
+:let bg_yellow_light_soft = ' guibg='.yellow_light_soft
 
 :let fg_green_xlight = ' guifg='.green_xlight
 :let fg_green_light  = ' guifg='.green_light
@@ -337,12 +343,12 @@ if &background == "dark"
   :exe 'hi cssStringQQ'            .fg_purple_xlight
   :exe 'hi cssValueLength'         .fg_gray30
   :exe 'hi cssValueTime'           .fg_gray30
-  :exe 'hi cssCommonAttr'          .fg_gray60
   :exe 'hi cssRenderProp'          .fg_gray60
   :exe 'hi cssUnitDecorators'      .fg_gray60
   :exe 'hi cssValueNumber'         .fg_gray30
   :exe 'hi cssRenderAttr'          .fg_gray30
   :exe 'hi cssUIAttr'              .fg_gray30
+  :exe 'hi cssCommonAttr'          .fg_gray30
   :exe 'hi cssPseudoClass'         .fg_purple_xlight
   :exe 'hi sassProperty'           .fg_red_dark
   :exe 'hi sassMixing'             .fg_red_dark
@@ -609,11 +615,27 @@ endif
 :exe 'hi javascriptEndColons'     .fg_gray50
 :exe 'hi jsNull'                  .fg_white . gui_bold
 :exe 'hi javascriptNull'          .fg_white . gui_bold
-:exe 'hi javascriptStatement'     .fg_green_light
-:exe 'hi javascriptRepeat'        .fg_green_light
-
-" JST/EJS
 :exe 'hi jstDelimiter'            .fg_green_xlight
+
+" Python
+if &background == "dark"
+  :exe 'hi pythonStatement'       .fg_white . gui_bold
+  :exe 'hi pythonDecorator'       .fg_yellow_xlight . gui_bold
+  :exe 'hi pythonFunction'        .fg_yellow_light
+  :exe 'hi pythonRepeat'          .fg_yellow_light
+  :exe 'hi pythonOperator'        .fg_yellow_light
+  :exe 'hi djangoVarBlock'        .fg_yellow_med
+  :exe 'hi pythonConditional'     .fg_yellow_med
+  :exe 'hi pythonException'       .fg_yellow_dark
+  :exe 'hi djangoArgument'        .fg_yellow_dark
+  :exe 'hi pythonString'          .fg_yellow_dark
+  :exe 'hi pythonBuiltin'         .fg_yellow_xdark
+  :exe 'hi pythonBoolean'         .fg_yellow_xdark
+  :exe 'hi pythonNumber'          .fg_yellow_xdark
+  :exe 'hi pythonImport'          .fg_yellow_muted
+  :exe 'hi pythonDottedName'      .fg_yellow_muted
+  :exe 'hi djangoTagBlock'        .fg_yellow_muted
+endif
 
 " Git
 if &background == "dark"

--- a/vim/lavalamp.vim
+++ b/vim/lavalamp.vim
@@ -307,6 +307,8 @@ if &background == "dark"
   :exe 'hi cssClassName'           .fg_purple_xlight
   :exe 'hi cssIdentifier'          .fg_purple_dark . gui_bold
   :exe 'hi cssBraces'              .fg_purple_xdark
+  :exe 'hi cssSelectorOp'          .fg_purple_xdark
+  :exe 'hi cssSelectorOp2'         .fg_purple_xdark
   :exe 'hi cssNoise'               .fg_purple_dark
   :exe 'hi cssMediaQuery'          .fg_purple_dark
   :exe 'hi cssMedia'               .fg_gray30. gui_bold
@@ -336,8 +338,11 @@ if &background == "dark"
   :exe 'hi cssValueLength'         .fg_gray30
   :exe 'hi cssValueTime'           .fg_gray30
   :exe 'hi cssCommonAttr'          .fg_gray60
+  :exe 'hi cssRenderProp'          .fg_gray60
   :exe 'hi cssUnitDecorators'      .fg_gray60
   :exe 'hi cssValueNumber'         .fg_gray30
+  :exe 'hi cssRenderAttr'          .fg_gray30
+  :exe 'hi cssUIAttr'              .fg_gray30
   :exe 'hi cssPseudoClass'         .fg_purple_xlight
   :exe 'hi sassProperty'           .fg_red_dark
   :exe 'hi sassMixing'             .fg_red_dark
@@ -358,6 +363,8 @@ else
   :exe 'hi cssClassName'           .fg_purple_xdark
   :exe 'hi cssIdentifier'          .fg_purple_light . gui_bold
   :exe 'hi cssBraces'              .fg_purple_xlight
+  :exe 'hi cssSelectorOp'          .fg_purple_xlight
+  :exe 'hi cssSelectorOp2'         .fg_purple_xlight
   :exe 'hi cssNoise'               .fg_purple_light
   :exe 'hi cssMediaQuery'          .fg_purple_light
   :exe 'hi cssMedia'               .fg_gray90. gui_bold
@@ -387,8 +394,11 @@ else
   :exe 'hi cssValueLength'         .fg_gray90
   :exe 'hi cssValueTime'           .fg_gray90
   :exe 'hi cssCommonAttr'          .fg_gray60
+  :exe 'hi cssRenderProp'          .fg_gray60
   :exe 'hi cssUnitDecorators'      .fg_gray60
   :exe 'hi cssValueNumber'         .fg_gray90
+  :exe 'hi cssRenderAttr'          .fg_gray90
+  :exe 'hi cssUIAttr'              .fg_gray90
   :exe 'hi cssPseudoClass'         .fg_purple_xdark
   :exe 'hi sassProperty'           .fg_red_light
   :exe 'hi sassComment'            .fg_gray50
@@ -504,8 +514,7 @@ else
 endif
 
 " Javascript
-" The javascript prefixed versions rely on https://github.com/jelera/vim-javascript-syntax
-" which is recommended.
+" Best with https://github.com/jelera/vim-javascript-syntax
 :exe 'hi jsPrototype'             .fg_green_med
 :exe 'hi javascriptPrototype'     .fg_green_med
 :exe 'hi jsExceptions'            .fg_green_med


### PR DESCRIPTION
I noticed this when going through a .css file:
![screen shot 1730-10-30 at 14 31 21](https://cloud.githubusercontent.com/assets/2810764/3500062/0a953218-0607-11e4-9415-d1153908928a.png)

and thought it looked out of place so I changed it to this:
![screen shot 1730-10-30 at 14 38 26](https://cloud.githubusercontent.com/assets/2810764/3500065/1448e3d6-0607-11e4-9878-63c3136ffcc9.png)

as always, let me know what you think!
